### PR TITLE
Add RejectAuth

### DIFF
--- a/relay.go
+++ b/relay.go
@@ -43,6 +43,7 @@ type Relay struct {
 	ServiceURL string
 
 	RejectEvent               []func(ctx context.Context, event *nostr.Event) (reject bool, msg string)
+	RejectAuth                []func(ctx context.Context, event *nostr.Event, challenge string) (reject bool, msg string)
 	RejectFilter              []func(ctx context.Context, filter nostr.Filter) (reject bool, msg string)
 	RejectCountFilter         []func(ctx context.Context, filter nostr.Filter) (reject bool, msg string)
 	OverwriteDeletionOutcome  []func(ctx context.Context, target *nostr.Event, deletion *nostr.Event) (acceptDeletion bool, msg string)


### PR DESCRIPTION
@fiatjaf I don't think you'll like this, because it makes auth vulnerable for existing projects. But see https://github.com/nostr-protocol/nips/pull/1079 for why I did it. I think this structure is better anyway, since it matches rejectx, but it does require the developer to validate the auth challenge.