### PR TITLE
Optimised CORS Headers + Small fixes

### DIFF
--- a/blossom/server.go
+++ b/blossom/server.go
@@ -3,11 +3,9 @@ package blossom
 import (
 	"context"
 	"io"
-	"net/http"
 
 	"github.com/fiatjaf/khatru"
 	"github.com/nbd-wtf/go-nostr"
-	"github.com/rs/cors"
 )
 
 type BlossomServer struct {
@@ -29,30 +27,14 @@ func New(rl *khatru.Relay, serviceURL string) *BlossomServer {
 		ServiceURL: serviceURL,
 	}
 
-	base := rl.Router()
+	mux := rl.Router()
 
-	blossomApi := http.NewServeMux()
-	blossomApi.HandleFunc("PUT /upload", bs.handleUpload)
-	blossomApi.HandleFunc("HEAD /upload", bs.handleUploadCheck)
-	blossomApi.HandleFunc("GET /list/{pubkey}", bs.handleList)
-	blossomApi.HandleFunc("HEAD /{sha256}", bs.handleHasBlob)
-	blossomApi.HandleFunc("GET /{sha256}", bs.handleGetBlob)
-	blossomApi.HandleFunc("DELETE /{sha256}", bs.handleDelete)
-	blossomApi.Handle("/", base) // forwards to relay
-
-	bud01CorsMux := cors.New(cors.Options{
-		AllowedOrigins: []string{"*"},
-		AllowedMethods: []string{"GET", "PUT", "DELETE"},
-		AllowedHeaders: []string{"Authorization", "*"},
-		MaxAge:         86400,
-	})
-
-	wrappedBlossomApi := bud01CorsMux.Handler(blossomApi)
-
-	combinedMux := http.NewServeMux()
-	combinedMux.Handle("/", wrappedBlossomApi)
-
-	rl.SetRouter(combinedMux)
+	mux.HandleFunc("PUT /upload", bs.handleUpload)
+	mux.HandleFunc("HEAD /upload", bs.handleUploadCheck)
+	mux.HandleFunc("GET /list/{pubkey}", bs.handleList)
+	mux.HandleFunc("HEAD /{sha256}", bs.handleHasBlob)
+	mux.HandleFunc("GET /{sha256}", bs.handleGetBlob)
+	mux.HandleFunc("DELETE /{sha256}", bs.handleDelete)
 
 	return bs
 }

--- a/blossom/server.go
+++ b/blossom/server.go
@@ -45,6 +45,7 @@ func New(rl *khatru.Relay, serviceURL string) *BlossomServer {
 		AllowedOrigins: []string{"*"},
 		AllowedMethods: []string{"GET", "PUT", "DELETE"},
 		AllowedHeaders: []string{"Authorization", "*"},
+		MaxAge:         86400,
 	})
 
 	wrappedBlossomApi := bud01CorsMux.Handler(blossomApi)

--- a/blossom/utils.go
+++ b/blossom/utils.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 )
 
-func setCors(w http.ResponseWriter) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
-}
+//func setCors(w http.ResponseWriter) {
+//	w.Header().Set("Access-Control-Allow-Origin", "*")
+//	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
+//	w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
+//}
 
 func blossomError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Add("X-Reason", msg)

--- a/blossom/utils.go
+++ b/blossom/utils.go
@@ -5,12 +5,6 @@ import (
 	"net/http"
 )
 
-//func setCors(w http.ResponseWriter) {
-//	w.Header().Set("Access-Control-Allow-Origin", "*")
-//	w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type")
-//	w.Header().Set("Access-Control-Allow-Methods", "GET, PUT, DELETE, OPTIONS")
-//}
-
 func blossomError(w http.ResponseWriter, msg string, code int) {
 	w.Header().Add("X-Reason", msg)
 	w.WriteHeader(code)

--- a/examples/blossom/main.go
+++ b/examples/blossom/main.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 
 	"github.com/fiatjaf/eventstore/badger"
 	"github.com/fiatjaf/khatru"
@@ -29,9 +31,10 @@ func main() {
 		fmt.Println("storing", sha256, len(body))
 		return nil
 	})
-	bl.LoadBlob = append(bl.LoadBlob, func(ctx context.Context, sha256 string) ([]byte, error) {
+	bl.LoadBlob = append(bl.LoadBlob, func(ctx context.Context, sha256 string) (io.Reader, error) {
 		fmt.Println("loading", sha256)
-		return []byte("aaaaa"), nil
+		blob := strings.NewReader("aaaaa")
+		return blob, nil
 	})
 
 	fmt.Println("running on :3334")

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/liamg/magic v0.0.1
 	github.com/nbd-wtf/go-nostr v0.42.0
 	github.com/puzpuzpuz/xsync/v3 v3.4.0
-	github.com/rs/cors v1.7.0
+	github.com/rs/cors v1.11.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -134,6 +134,8 @@ github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/rs/cors v1.7.0 h1:+88SsELBHx5r+hZ8TCkggzSstaWNbDvThkVK8H6f9ik=
 github.com/rs/cors v1.7.0/go.mod h1:gFx+x8UowdsKA9AchylcLynDq+nNFfI8FkUZdN/jGCU=
+github.com/rs/cors v1.11.1 h1:eU3gRzXLRK57F5rKMGMZURNdIG4EoAmX8k94r9wXWHA=
+github.com/rs/cors v1.11.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee h1:8Iv5m6xEo1NR1AvpV+7XmhI4r39LGNzwUL4YpMuL5vk=
 github.com/savsgio/gotils v0.0.0-20230208104028-c358bd845dee/go.mod h1:qwtSXrKuJh/zsFQ12yEE89xfCrGKK63Rr7ctU/uCo4g=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=

--- a/policies/events.go
+++ b/policies/events.go
@@ -72,7 +72,7 @@ func RestrictToSpecifiedKinds(allowEphemeral bool, kinds ...uint16) func(context
 	slices.Sort(kinds)
 
 	return func(ctx context.Context, event *nostr.Event) (reject bool, msg string) {
-		if allowEphemeral && event.IsEphemeral() {
+		if allowEphemeral && nostr.IsEphemeralKind(event.Kind) {
 			return false, ""
 		}
 


### PR DESCRIPTION
- Use `rs/cors` to serve all CORS headers
- Cache CORS pre-flight requests for up to 24 hours, depending on the browser
- Update Blossom example to use `io.Reader`
- Fix policies that rely on the removed `Event.IsEphemeral` method