### PR TITLE
Change API of LoadBlob to return io.ReadSeeker instead of io.Reader and use ServeContent to serve blob content

### DIFF
--- a/blossom/handlers.go
+++ b/blossom/handlers.go
@@ -4,7 +4,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"fmt"
 	"io"
 	"mime"
 	"net/http"
@@ -195,11 +194,9 @@ func (bs BlossomServer) handleGetBlob(w http.ResponseWriter, r *http.Request) {
 			descriptor, err := bs.Store.Get(r.Context(), hhash)
 			readSeeker, ok := reader.(io.ReadSeeker)
 			if ok && err == nil && descriptor != nil {
-				fmt.Println("serving content", descriptor)
 				http.ServeContent(w, r, hhash+ext, descriptor.Uploaded.Time(), readSeeker)
 			} else {
 				// if not a readseeker, or no descriptor reverts to previous behaviour
-				fmt.Println("serving content without descriptor", ok, err, descriptor)
 				io.Copy(w, reader)
 			}
 			return

--- a/blossom/handlers.go
+++ b/blossom/handlers.go
@@ -199,6 +199,7 @@ func (bs BlossomServer) handleGetBlob(w http.ResponseWriter, r *http.Request) {
 				http.ServeContent(w, r, hhash+ext, descriptor.Uploaded.Time(), readSeeker)
 			} else {
 				// if not a readseeker, or no descriptor reverts to previous behaviour
+				fmt.Println("serving content without descriptor", ok, err, descriptor)
 				io.Copy(w, reader)
 			}
 			return

--- a/blossom/server.go
+++ b/blossom/server.go
@@ -15,7 +15,7 @@ type BlossomServer struct {
 	Store      BlobIndex
 
 	StoreBlob  []func(ctx context.Context, sha256 string, body []byte) error
-	LoadBlob   []func(ctx context.Context, sha256 string) (io.Reader, error)
+	LoadBlob   []func(ctx context.Context, sha256 string) (io.ReadSeeker, error)
 	DeleteBlob []func(ctx context.Context, sha256 string) error
 
 	RejectUpload []func(ctx context.Context, auth *nostr.Event, size int, ext string) (bool, string, int)


### PR DESCRIPTION
This is an improvement over the previous PR #18  that is not backward compatible, but makes more sense since the reader needs to be seekable to be compatible with iOS and other modern browsers/media players.