### PR TITLE
ensure suspected blossom request hash does not have slashes in it

### DIFF
--- a/blossom/server.go
+++ b/blossom/server.go
@@ -49,7 +49,7 @@ func New(rl *khatru.Relay, serviceURL string) *BlossomServer {
 			return
 		}
 
-		if len(strings.SplitN(r.URL.Path, ".", 2)[0]) == 65 {
+		if (len(r.URL.Path) == 65 || strings.Index(r.URL.Path, ".") == 65) && strings.Index(r.URL.Path, "/") == -1 {
 			if r.Method == "HEAD" {
 				bs.handleHasBlob(w, r)
 				return


### PR DESCRIPTION
I noticed certain URLs would be caught by the blossom url handler if they coincidentally split at 64 bytes. I am using a few extra path handlers.

This change adds a check for slashes.  I was thinking a regex test might be better, but perhaps too resource heavy so just kept it as a Index call. Let me know if you prefer a regex test instead.