### PR TITLE
blossom: redirect support

### DIFF
--- a/blossom/handlers.go
+++ b/blossom/handlers.go
@@ -215,7 +215,11 @@ func (bs BlossomServer) handleGetBlob(w http.ResponseWriter, r *http.Request) {
 			}
 			w.Header().Set("ETag", hhash)
 			w.Header().Set("Cache-Control", "public, max-age=604800, immutable")
-			http.ServeContent(w, r, hhash+"."+ext, t, reader)
+			name := hhash
+			if ext != "" {
+				name += "." + ext
+			}
+			http.ServeContent(w, r, name, t, reader)
 			return
 		}
 	}

--- a/blossom/server.go
+++ b/blossom/server.go
@@ -18,6 +18,7 @@ type BlossomServer struct {
 	LoadBlob      []func(ctx context.Context, sha256 string) (io.ReadSeeker, error)
 	DeleteBlob    []func(ctx context.Context, sha256 string) error
 	ReceiveReport []func(ctx context.Context, reportEvt *nostr.Event) error
+	RedirectGet   []func(ctx context.Context, sha256 string, fileExtension string) (url string, code int, err error)
 
 	RejectUpload []func(ctx context.Context, auth *nostr.Event, size int, ext string) (bool, string, int)
 	RejectGet    []func(ctx context.Context, auth *nostr.Event, sha256 string) (bool, string, int)

--- a/blossom/server.go
+++ b/blossom/server.go
@@ -26,9 +26,27 @@ type BlossomServer struct {
 	RejectDelete []func(ctx context.Context, auth *nostr.Event, sha256 string) (bool, string, int)
 }
 
-func New(rl *khatru.Relay, serviceURL string) *BlossomServer {
+// ServerOption represents a functional option for configuring a BlossomServer
+type ServerOption func(*BlossomServer)
+
+// WithRedirectURL configures a redirect URL for the RedirectGet function
+func WithRedirectURL(urlTemplate string, statusCode int) ServerOption {
+	return func(bs *BlossomServer) {
+		redirectFn := redirectGet(urlTemplate, statusCode)
+		bs.RedirectGet = append(bs.RedirectGet, redirectFn)
+	}
+}
+
+// New creates a new BlossomServer with the given relay and service URL
+// Optional configuration can be provided via functional options
+func New(rl *khatru.Relay, serviceURL string, opts ...ServerOption) *BlossomServer {
 	bs := &BlossomServer{
 		ServiceURL: serviceURL,
+	}
+
+	// Apply any provided options
+	for _, opt := range opts {
+		opt(bs)
 	}
 
 	base := rl.Router()
@@ -84,4 +102,41 @@ func New(rl *khatru.Relay, serviceURL string) *BlossomServer {
 	rl.SetRouter(mux)
 
 	return bs
+}
+
+// redirectGet returns a function that redirects to a specified URL template with the given status code.
+// The URL template can include {sha256} and/or {extension} placeholders that will be replaced
+// with the actual values. If neither placeholder is present, {sha256}.{extension} will be
+// appended to the URL with proper forward slash handling.
+func redirectGet(urlTemplate string, statusCode int) func(context.Context, string, string) (url string, code int, err error) {
+	return func(ctx context.Context, sha256 string, extension string) (string, int, error) {
+		finalURL := urlTemplate
+
+		// Replace placeholders if they exist
+		hasSHA256Placeholder := strings.Contains(finalURL, "{sha256}")
+		hasExtensionPlaceholder := strings.Contains(finalURL, "{extension}")
+
+		if hasSHA256Placeholder {
+			finalURL = strings.Replace(finalURL, "{sha256}", sha256, -1)
+		}
+
+		if hasExtensionPlaceholder {
+			finalURL = strings.Replace(finalURL, "{extension}", extension, -1)
+		}
+
+		// If neither placeholder is present, append sha256.extension
+		if !hasSHA256Placeholder && !hasExtensionPlaceholder {
+			// Ensure URL ends with a forward slash
+			if !strings.HasSuffix(finalURL, "/") {
+				finalURL += "/"
+			}
+
+			finalURL += sha256
+			if extension != "" {
+				finalURL += "." + extension
+			}
+		}
+
+		return finalURL, statusCode, nil
+	}
 }

--- a/docs/core/blossom.md
+++ b/docs/core/blossom.md
@@ -47,6 +47,52 @@ You can integrate any storage backend by implementing the three core functions:
 - `LoadBlob`: Retrieve the blob data
 - `DeleteBlob`: Remove the blob data
 
+## URL Redirection
+
+Blossom supports redirection to external storage locations when retrieving blobs. This is useful when you want to serve files from a CDN or cloud storage service while keeping Blossom compatibility.
+
+### Simple Redirect
+
+You can use the `WithRedirectURL` option when creating your Blossom server to enable this functionality:
+
+```go
+// Create blossom server with redirection enabled
+bl := blossom.New(
+    relay, 
+    "http://localhost:3334",
+    blossom.WithRedirectURL("https://blossom.exampleserver.com", http.StatusMovedPermanently),
+)
+```
+
+By default the `WithRedirectURL` option will append the blob's SHA256 hash and file extension to the redirect URL.
+For example, if the blob's SHA256 hash is `b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553` and the file extension is `pdf`, 
+the redirect URL will be https://blossom.exampleserver.com/b1674191a88ec5cdd733e4240a81803105dc412d6c6708d53ab94fc248f4f553.pdf.
+
+### Redirect URL placeholders
+
+You can also customize the redirect URL by passing `{sha256}` and `{extension}` placeholders in the URL. For example:
+
+```go
+bl := blossom.New(
+    relay, 
+    "http://localhost:3334",
+    blossom.WithRedirectURL("https://mybucket.myblobstorage.com/{sha256}.{extension}?ref=xxxx", http.StatusFound),
+)
+```
+
+### Custom Redirect Function
+
+If you need more control over the redirect URL, you can implement a custom redirect function. This function should return a string with the redirect URL and an HTTP status code.
+
+```go
+bl.RedirectGet = append(bl.RedirectGet, func(ctx context.Context, sha256 string, ext string) (string, int, error) {
+    // generate a custom redirect URL
+    cid := IpfsCID(sha256)
+	redirectURL := fmt.Sprintf("https://ipfs.io/ipfs/%s/%s.%s", cid, sha256, ext)
+    return redirectURL, http.StatusTemporaryRedirect, nil
+})
+```
+
 ## Upload Restrictions
 
 You can implement upload restrictions using the `RejectUpload` hook. Here's an example that limits file size and restricts uploads to whitelisted users:


### PR DESCRIPTION
feat(blossom): add redirect support for GET requests

As far as I can tell these changes are backwards compatible since the new events are optional and the default redirect implementation is hidden behind a new option (variadic Function configuration).

This is just a first draft, but tests with both Cloudflare R2 and IPFS are looking promising so far.