### PR TITLE
fix(deleting): handle relay URLs with port numbers using SplitN

### DIFF
--- a/deleting.go
+++ b/deleting.go
@@ -19,7 +19,7 @@ func (rl *Relay) handleDeleteRequest(ctx context.Context, evt *nostr.Event) erro
 			case "e":
 				f = nostr.Filter{IDs: []string{tag[1]}}
 			case "a":
-				spl := strings.Split(tag[1], ":")
+				spl := strings.SplitN(tag[1], ":", 3)
 				if len(spl) != 3 {
 					continue
 				}


### PR DESCRIPTION
I ran into a small issue when working with delete events: if the `<d-identifier>` is a relay URL includes a port (like `ws://127.0.0.1:3334/`), the current parsing breaks and the event can’t be processed.

<img width="1579" height="819" alt="image" src="https://github.com/user-attachments/assets/b33a5791-3a42-48a9-b306-a049142d3d13" />


This PR adjusts the splitting logic so the URL stays intact, which makes deletions work as expected. It’s just a small tweak, but really helpful during local development.